### PR TITLE
Update foreman-remote-execution/nightly/index.md

### DIFF
--- a/plugins/foreman_remote_execution/nightly/index.md
+++ b/plugins/foreman_remote_execution/nightly/index.md
@@ -198,7 +198,7 @@ If you prefer to distribute the keys manually, you may do this:
 Alternatively, the Smart Proxy publishes the public key over the API, so that
 one can just download it into authorized keys:
 
-    curl https://myproxy.example.com:8443/ssh/pubkey >> ~/.ssh/authorized_keys
+    curl https://myproxy.example.com:9090/ssh/pubkey >> ~/.ssh/authorized_keys
 
 For the execution to work, the client needs to have **openssh-server**
 installed and configured.  Also, **openssh-clients** need to be present, in


### PR DESCRIPTION
Edit the port used to curl the public key from the API to reflect the new default of 9090